### PR TITLE
loginのdelete_flag処理とadminでshoppingスタイルをチェックできなくする。国の選び直し処理を作成

### DIFF
--- a/admin.php
+++ b/admin.php
@@ -43,9 +43,9 @@
     }
     //繰り返し終了
 
-    //$find_country_arrayに含まれるstyle_nameを使って、user_numberを取得する
+    //$find_style_arrayに含まれるstyle_nameを使って、user_numberを取得する
     foreach($find_style_array as $data) {
-      //$$cnameで配列名を成立させるために、$data['country_name']のスペースを詰める処理
+      //$$cnameで配列名を成立させるために、$data['style_name']のスペースを詰める処理
       $sname = str_replace(" ","",$data['style_name']);
       if ($data['style_name'] == $sname) {
         $$sname = $data['user_number'];
@@ -133,8 +133,12 @@
     }
 
   //書き直しの処理
+  $select_country = array();
   if (isset($_REQUEST['action']) && $_REQUEST['action'] == 'rewrite'){
     $_POST = $_SESSION['admin'];
+    var_dump($_SESSION['admin']['country']);
+    $select_country = $_SESSION['admin']['country'];
+    var_dump($select_country);
     $error['rewrite'] = true;
   }
 
@@ -266,7 +270,7 @@
             </div>
             <div class="col-xs-6 col-sm-6 col-md-4 col-lg-4">
                 <label class="checkbox-inline" for="shopping">
-                  <input type="checkbox" name="style[]" id="shopping" value="shopping">
+                  <input type="checkbox" name="style[]" id="shopping" value="shopping" disabled='disabled' checked='checked'>
                   ショッピング：<?php echo $shopping ?>
                 </label>
             </div>
@@ -298,94 +302,199 @@
         <div class="col-md-12 columns">
             <h3>Asia</h3>
               <div class="col-xs-6 col-sm-6 col-md-3 col-lg-3">
+                <?php if(in_array("UnitedArabEmirates", $select_country)) { ?>
+                <label class="checkbox-inline" for="UnitedArabEmirates">
+                  <input type="checkbox" name="country[]" value="UnitedArabEmirates" checked='checked'>
+                  アラブ首長国連邦：<?php echo $UnitedArabEmirates ?>
+                </label>
+                <?php }else{ ?>
                 <label class="checkbox-inline" for="UnitedArabEmirates">
                   <input type="checkbox" name="country[]" value="UnitedArabEmirates">
                   アラブ首長国連邦：<?php echo $UnitedArabEmirates ?>
                 </label>
+                <?php } ?>
               </div>
               <div class="col-xs-6 col-sm-6 col-md-3 col-lg-3">
+                <?php if(in_array("India", $select_country)) { ?>
+                <label class="checkbox-inline" for="India">
+                  <input type="checkbox" name="country[]" value="India" checked='checked'>
+                  インド：<?php echo $India ?>
+                </label>
+                <?php }else{ ?>
                 <label class="checkbox-inline" for="India">
                   <input type="checkbox" name="country[]" value="India">
                   インド：<?php echo $India ?>
                 </label>
+                <?php } ?>
               </div>
               <div class="col-xs-6 col-sm-6 col-md-3 col-lg-3">
+                <?php if(in_array("Indonesia", $select_country)) { ?>
+                <label class="checkbox-inline" for="Indonesia">
+                  <input type="checkbox" name="country[]" value="Indonesia" checked='checked'>
+                  インドネシア：<?php echo $Indonesia ?>
+                </label>
+                <?php }else{ ?>
                 <label class="checkbox-inline" for="Indonesia">
                   <input type="checkbox" name="country[]" value="Indonesia">
                   インドネシア：<?php echo $Indonesia ?>
                 </label>
+                <?php } ?>
               </div>
               <div class="col-xs-6 col-sm-6 col-md-3 col-lg-3">
+                <?php if(in_array("Qatar", $select_country)) { ?>
+                <label class="checkbox-inline" for="Qatar">
+                  <input type="checkbox" name="country[]" value="Qatar" checked='checked'>
+                  カタール：<?php echo $Qatar ?>
+                </label>
+                <?php }else{ ?>
                 <label class="checkbox-inline" for="Qatar">
                   <input type="checkbox" name="country[]" value="Qatar">
                   カタール：<?php echo $Qatar ?>
                 </label>
+                <?php } ?>
               </div>
               <div class="col-xs-6 col-sm-6 col-md-3 col-lg-3">
+                <?php if(in_array("Korea", $select_country)) { ?>
+                <label class="checkbox-inline" for="Korea">
+                  <input type="checkbox" name="country[]" value="Korea" checked='checked'>
+                  韓国：<?php echo $Korea ?>
+                </label>
+                <?php }else{ ?>
                 <label class="checkbox-inline" for="Korea">
                   <input type="checkbox" name="country[]" value="Korea">
                   韓国：<?php echo $Korea ?>
                 </label>
+                <?php } ?>
               </div>
               <div class="col-xs-6 col-sm-6 col-md-3 col-lg-3">
+                <?php if(in_array("Cambodia", $select_country)) { ?>
+                <label class="checkbox-inline" for="Cambodia">
+                  <input type="checkbox" name="country[]" value="Cambodia" checked='checked'>
+                  カンボジア：<?php echo $Cambodia ?>
+                </label>
+                <?php }else{ ?>
                 <label class="checkbox-inline" for="Cambodia">
                   <input type="checkbox" name="country[]" value="Cambodia">
                   カンボジア：<?php echo $Cambodia ?>
                 </label>
+                <?php } ?>
               </div>
               <div class="col-xs-6 col-sm-6 col-md-3 col-lg-3">
+                <?php if(in_array("Singapore", $select_country)) { ?>
+                <label class="checkbox-inline" for="Singapore">
+                  <input type="checkbox" name="country[]" value="Singapore" checked='checked'>
+                  シンガポール：<?php echo $Singapore ?>
+                </label>
+                <?php }else{ ?>
                 <label class="checkbox-inline" for="Singapore">
                   <input type="checkbox" name="country[]" value="Singapore">
                   シンガポール：<?php echo $Singapore ?>
                 </label>
+                <?php } ?>
               </div>
               <div class="col-xs-6 col-sm-6 col-md-3 col-lg-3">
-                <label class="checkbox-inline" for="thailand">
-                  <input type="checkbox" name="country[]" id="thailand" value="Thailand">
+                <?php if(in_array("Thailand", $select_country)) { ?>
+                <label class="checkbox-inline" for="Thailand">
+                  <input type="checkbox" name="country[]" id="Thailand" value="Thailand" checked='checked'>
                   タイ：<?php echo $Thailand ?>
                 </label>
+                <?php }else{ ?>
+                <label class="checkbox-inline" for="Thailand">
+                  <input type="checkbox" name="country[]" id="Thailand" value="Thailand">
+                  タイ：<?php echo $Thailand ?>
+                </label>
+                <?php } ?>
               </div>
               <div class="col-xs-6 col-sm-6 col-md-3 col-lg-3">
+                <?php if(in_array("Taiwan", $select_country)) { ?>
+                <label class="checkbox-inline" for="taiwan">
+                  <input type="checkbox" name="country[]" id="taiwan" value="Taiwan" checked='checked'>
+                  台湾：<?php echo $Taiwan ?>
+                </label>
+                <?php }else{ ?>
                 <label class="checkbox-inline" for="taiwan">
                   <input type="checkbox" name="country[]" id="taiwan" value="Taiwan">
                   台湾：<?php echo $Taiwan ?>
                 </label>
+                <?php } ?>
               </div>
               <div class="col-xs-6 col-sm-6 col-md-3 col-lg-3">
+                <?php if(in_array("China", $select_country)) { ?>
+                <label class="checkbox-inline" for="china">
+                  <input type="checkbox" name="country[]" id="china" value="China" checked='checked'>
+                  中国：<?php echo $China ?>
+                </label>
+                <?php }else{ ?>
                 <label class="checkbox-inline" for="china">
                   <input type="checkbox" name="country[]" id="china" value="China">
                   中国：<?php echo $China ?>
                 </label>
+                <?php } ?>
               </div>
               <div class="col-xs-6 col-sm-6 col-md-3 col-lg-3">
+                <?php if(in_array("Turkey", $select_country)) { ?>
+                <label class="checkbox-inline" for="turkey">
+                  <input type="checkbox" name="country[]" id="turkey" value="Turkey" checked='checked'>
+                  トルコ：<?php echo $Turkey ?>
+                </label>
+                <?php }else{ ?>
                 <label class="checkbox-inline" for="turkey">
                   <input type="checkbox" name="country[]" id="turkey" value="Turkey">
                   トルコ：<?php echo $Turkey ?>
                 </label>
+                <?php } ?>
               </div>
               <div class="col-xs-6 col-sm-6 col-md-3 col-lg-3">
+                <?php if(in_array("Philippines", $select_country)) { ?>
+                <label class="checkbox-inline" for="philippines">
+                  <input type="checkbox" name="country[]" id="philippines" value="Philippines" checked='checked'>
+                  フィリピン：<?php echo $Philippines ?>
+                </label>
+                <?php }else{ ?>
                 <label class="checkbox-inline" for="philippines">
                   <input type="checkbox" name="country[]" id="philippines" value="Philippines">
                   フィリピン：<?php echo $Philippines ?>
                 </label>
+                <?php } ?>
               </div>
               <div class="col-xs-6 col-sm-6 col-md-3 col-lg-3">
+                <?php if(in_array("VietNam", $select_country)) { ?>
+                <label class="checkbox-inline" for="vietnam">
+                  <input type="checkbox" name="country[]" id="vietnam" value="VietNam" checked='checked'>
+                  ベトナム：<?php echo $VietNam ?>
+                </label>
+                <?php }else{ ?>
                 <label class="checkbox-inline" for="vietnam">
                   <input type="checkbox" name="country[]" id="vietnam" value="VietNam">
                   ベトナム：<?php echo $VietNam ?>
                 </label>
+                <?php } ?>
               </div>
               <div class="col-xs-6 col-sm-6 col-md-3 col-lg-3">
+                <?php if(in_array("HongKong", $select_country)) { ?>
+                <label class="checkbox-inline" for="HongKong">
+                  <input type="checkbox" name="country[]" id="hongkong_macao" value="HongKong" checked='checked'>
+                  香港・マカオ：<?php echo $HongKong ?>
+                </label>
+                <?php }else{ ?>
                 <label class="checkbox-inline" for="HongKong">
                   <input type="checkbox" name="country[]" id="hongkong_macao" value="HongKong">
                   香港・マカオ：<?php echo $HongKong ?>
                 </label>
+                <?php } ?>
               </div>
               <div class="col-xs-6 col-sm-6 col-md-3 col-lg-3">
+                <?php if(in_array("Malaysia", $select_country)) { ?>
+                <label class="checkbox-inline" for="malaysia">
+                  <input type="checkbox" name="country[]" id="malaysia" value="Malaysia" checked='checked'>
+                  マレーシア：<?php echo $Malaysia ?>
+                </label><br><br>
+                <?php }else{ ?>
                 <label class="checkbox-inline" for="malaysia">
                   <input type="checkbox" name="country[]" id="malaysia" value="Malaysia">
                   マレーシア：<?php echo $Malaysia ?>
                 </label><br><br>
+                <?php } ?>
               </div>
         </div>
       </div>
@@ -394,40 +503,82 @@
         <div class="col-md-12 columns">
             <h3>Oceania</h3>
               <div class="col-xs-6 col-sm-6 col-md-3 col-lg-3">
+                <?php if(in_array("Australia", $select_country)) { ?>
+                <label class="checkbox-inline" for="austraria">
+                  <input type="checkbox" name="country[]" id="austraria" value="Australia" checked='checked'>
+                  オーストラリア：<?php echo $Australia ?>
+                </label>
+                <?php }else{ ?>
                 <label class="checkbox-inline" for="austraria">
                   <input type="checkbox" name="country[]" id="austraria" value="Australia">
                   オーストラリア：<?php echo $Australia ?>
                 </label>
+                <?php } ?>
               </div>
               <div class="col-xs-6 col-sm-6 col-md-3 col-lg-3">
+                <?php if(in_array("Guam", $select_country)) { ?>
+                <label class="checkbox-inline" for="guam">
+                  <input type="checkbox" name="country[]" id="guam" value="Guam" checked='checked'>
+                  グアム：<?php echo $Guam ?>
+                </label>
+                <?php }else{ ?>
                 <label class="checkbox-inline" for="guam">
                   <input type="checkbox" name="country[]" id="guam" value="Guam">
                   グアム：<?php echo $Guam ?>
                 </label>
+                <?php } ?>
               </div>
               <div class="col-xs-6 col-sm-6 col-md-3 col-lg-3">
+                <?php if(in_array("Saipan", $select_country)) { ?>
+                <label class="checkbox-inline" for="saipan">
+                  <input type="checkbox" name="country[]" id="saipan" value="Saipan" checked='checked'>
+                  サイパン：<?php echo $Saipan ?>
+                </label>
+                <?php }else{ ?>
                 <label class="checkbox-inline" for="saipan">
                   <input type="checkbox" name="country[]" id="saipan" value="Saipan">
                   サイパン：<?php echo $Saipan ?>
                 </label>
+                <?php } ?>
               </div>
               <div class="col-xs-6 col-sm-6 col-md-3 col-lg-3">
+                <?php if(in_array("NewCaledonia", $select_country)) { ?>
+                <label class="checkbox-inline" for="newcaledonia">
+                  <input type="checkbox" name="country[]" id="newcaledonia" value="NewCaledonia" checked='checked'>
+                  ニューカレドニア：<?php echo $NewCaledonia ?>
+                </label>
+                <?php }else{ ?>
                 <label class="checkbox-inline" for="newcaledonia">
                   <input type="checkbox" name="country[]" id="newcaledonia" value="NewCaledonia">
                   ニューカレドニア：<?php echo $NewCaledonia ?>
                 </label>
+                <?php } ?>
               </div>
               <div class="col-xs-6 col-sm-6 col-md-3 col-lg-3">
+                <?php if(in_array("NewZealand", $select_country)) { ?>
+                <label class="checkbox-inline" for="newzealand">
+                  <input type="checkbox" name="country[]" id="newzealand" value="NewZealand" checked='checked'>
+                  ニュージーランド：<?php echo $NewZealand ?>
+                </label><br><br>
+                <?php }else{ ?>
                 <label class="checkbox-inline" for="newzealand">
                   <input type="checkbox" name="country[]" id="newzealand" value="NewZealand">
                   ニュージーランド：<?php echo $NewZealand ?>
                 </label><br><br>
+                <?php } ?>
               </div>
               <div class="col-xs-6 col-sm-6 col-md-3 col-lg-3">
+                <?php if(in_array("Hawaii", $select_country)) { ?>
+                <label class="checkbox-inline" for="hawaii">
+                  <input type="checkbox" name="country[]" id="hawaii" value="Hawaii" checked='checked'>
+                  ハワイ：<?php echo $Hawaii ?>
+                </label><br><br>
+                <?php }else{ ?>
                 <label class="checkbox-inline" for="hawaii">
                   <input type="checkbox" name="country[]" id="hawaii" value="Hawaii">
                   ハワイ：<?php echo $Hawaii ?>
                 </label><br><br>
+                <?php } ?>
               </div>
         </div>
       </div>
@@ -436,52 +587,108 @@
         <div class="col-md-12 columns">
             <h3>Europe</h3>
               <div class="col-xs-6 col-sm-6 col-md-3 col-lg-3">
+                <?php if(in_array("Ireland", $select_country)) { ?>
+                <label class="checkbox-inline" for="ireland">
+                  <input type="checkbox" name="country[]" id="ireland" value="Ireland" checked='checked'>
+                  アイルランド：<?php echo $Ireland ?>
+                </label>
+                <?php }else{ ?>
                 <label class="checkbox-inline" for="ireland">
                   <input type="checkbox" name="country[]" id="ireland" value="Ireland">
                   アイルランド：<?php echo $Ireland ?>
                 </label>
+                <?php } ?>
               </div>
               <div class="col-xs-6 col-sm-6 col-md-3 col-lg-3">
+                <?php if(in_array("UnitedKingdom", $select_country)) { ?>
+                <label class="checkbox-inline" for="uk">
+                  <input type="checkbox" name="country[]" id="uk" value="UnitedKingdom" checked='checked'>
+                  イギリス：<?php echo $UnitedKingdom ?>
+                </label>
+                <?php }else{ ?>
                 <label class="checkbox-inline" for="uk">
                   <input type="checkbox" name="country[]" id="uk" value="UnitedKingdom">
                   イギリス：<?php echo $UnitedKingdom ?>
                 </label>
+                <?php } ?>
               </div>
               <div class="col-xs-6 col-sm-6 col-md-3 col-lg-3">
+                <?php if(in_array("Italy", $select_country)) { ?>
+                <label class="checkbox-inline" for="italy">
+                  <input type="checkbox" name="country[]" id="italy" value="Italy" checked='checked'>
+                  イタリア：<?php echo $Italy ?>
+                </label>
+                <?php }else{ ?>
                 <label class="checkbox-inline" for="italy">
                   <input type="checkbox" name="country[]" id="italy" value="Italy">
                   イタリア：<?php echo $Italy ?>
                 </label>
+                <?php } ?>
               </div>
               <div class="col-xs-6 col-sm-6 col-md-3 col-lg-3">
+                <?php if(in_array("Netherlands", $select_country)) { ?>
+                <label class="checkbox-inline" for="netherland">
+                  <input type="checkbox" name="country[]" id="netherland" value="Netherlands" checked='checked'>
+                  オランダ：<?php echo $Netherlands ?>
+                </label>
+                <?php }else{ ?>
                 <label class="checkbox-inline" for="netherland">
                   <input type="checkbox" name="country[]" id="netherland" value="Netherlands">
                   オランダ：<?php echo $Netherlands ?>
                 </label>
+                <?php } ?>
               </div>
               <div class="col-xs-6 col-sm-6 col-md-3 col-lg-3">
+                <?php if(in_array("Spain", $select_country)) { ?>
+                <label class="checkbox-inline" for="spain">
+                  <input type="checkbox" name="country[]" id="spain" value="Spain" checked='checked'>
+                  スペイン：<?php echo $Spain ?>
+                </label>
+                <?php }else{ ?>
                 <label class="checkbox-inline" for="spain">
                   <input type="checkbox" name="country[]" id="spain" value="Spain">
                   スペイン：<?php echo $Spain ?>
                 </label>
+                <?php } ?>
               </div>
               <div class="col-xs-6 col-sm-6 col-md-3 col-lg-3">
+                <?php if(in_array("Finland", $select_country)) { ?>
+                <label class="checkbox-inline" for="finland">
+                  <input type="checkbox" name="country[]" id="finland" value="Finland" checked='checked'>
+                  フィンランド：<?php echo $Finland ?>
+                </label>
+                <?php }else{ ?>
                 <label class="checkbox-inline" for="finland">
                   <input type="checkbox" name="country[]" id="finland" value="Finland">
                   フィンランド：<?php echo $Finland ?>
                 </label>
+                <?php } ?>
               </div>
               <div class="col-xs-6 col-sm-6 col-md-3 col-lg-3">
+                <?php if(in_array("France", $select_country)) { ?>
+                <label class="checkbox-inline" for="france">
+                  <input type="checkbox" name="country[]" id="france" value="France" checked='checked'>
+                  フランス：<?php echo $France ?>
+                </label>
+                <?php }else{ ?>
                 <label class="checkbox-inline" for="france">
                   <input type="checkbox" name="country[]" id="france" value="France">
                   フランス：<?php echo $France ?>
                 </label>
+                <?php } ?>
               </div>
               <div class="col-xs-6 col-sm-6 col-md-3 col-lg-3">
+                <?php if(in_array("Russia", $select_country)) { ?>
+                <label class="checkbox-inline" for="russia">
+                  <input type="checkbox" name="country[]" id="russia" value="Russia" checked='checked'>
+                  ロシア：<?php echo $Russia ?>
+                </label><br><br>
+                <?php }else{ ?>
                 <label class="checkbox-inline" for="russia">
                   <input type="checkbox" name="country[]" id="russia" value="Russia">
                   ロシア：<?php echo $Russia ?>
                 </label><br><br>
+                <?php } ?>
               </div>
         </div>
       </div>
@@ -490,22 +697,43 @@
         <div class="col-md-12 columns">
             <h3>North_America</h3>
               <div class="col-xs-6 col-sm-6 col-md-3 col-lg-3">
+                <?php if(in_array("UnitedStates", $select_country)) { ?>
                 <label class="checkbox-inline" for="usa">
                   <input type="checkbox" name="country[]" id="usa" value="UnitedStates">
                   アメリカ：<?php echo $UnitedStates ?>
                 </label>
+                <?php }else{ ?>
+                 <label class="checkbox-inline" for="usa">
+                  <input type="checkbox" name="country[]" id="usa" value="UnitedStates">
+                  アメリカ：<?php echo $UnitedStates ?>
+                </label>
+                <?php } ?>
               </div>
               <div class="col-xs-6 col-sm-6 col-md-3 col-lg-3">
+                <?php if(in_array("Canada", $select_country)) { ?>
                 <label class="checkbox-inline" for="Canada">
                   <input type="checkbox" name="country[]" id="Canada" value="Canada">
                   カナダ：<?php echo $Canada ?>
                 </label>
+                <?php }else{ ?>
+                <label class="checkbox-inline" for="Canada">
+                  <input type="checkbox" name="country[]" id="Canada" value="Canada">
+                  カナダ：<?php echo $Canada ?>
+                </label>
+                <?php } ?>
               </div>
               <div class="col-xs-6 col-sm-6 col-md-3 col-lg-3">
+                <?php if(in_array("Mexico", $select_country)) { ?>
                 <label class="checkbox-inline" for="mexico">
                   <input type="checkbox" name="country[]" id="mexico" value="Mexico">
                   メキシコ：<?php echo $Mexico ?>
                 </label>
+                <?php }else{ ?>
+                <label class="checkbox-inline" for="mexico">
+                  <input type="checkbox" name="country[]" id="mexico" value="Mexico">
+                  メキシコ：<?php echo $Mexico ?>
+                </label>
+                <?php } ?>
               </div>
         </div>
       </div>

--- a/check.php
+++ b/check.php
@@ -16,8 +16,6 @@
   $password=htmlspecialchars($_SESSION['signup']['password'], ENT_QUOTES, 'UTF-8');
   $re_password=htmlspecialchars($_SESSION['signup']['re_password'], ENT_QUOTES, 'UTF-8');
 
-
-
   // //DB登録処理(ok)
   if (!empty($_POST)) {
     $sql = sprintf('INSERT INTO `users` (`nick_name`, `email`, `password`, `created`, `modified`) VALUES ("%s", "%s", "%s", now(), now());',

--- a/login.php
+++ b/login.php
@@ -29,7 +29,7 @@
         //ログイン処理を開始
         //入力されたemail,passwordでDBから会員情報を取得できたら、正常ログイン、取得できなかったら、$error['login']にfaildを代入して、
         //パスワードの下に「ログインに失敗しました。正しくご記入ください」とメッセージを表示する
-        $sql = sprintf('SELECT `email`, `password`, `user_id` FROM `users` WHERE `email` = "%s" AND `password` = "%s"',
+        $sql = sprintf('SELECT `email`, `password`, `user_id` FROM `users` WHERE `email` = "%s" AND `password` = "%s" AND `delete_flag` = 0',
         mysqli_real_escape_string($db,$_POST['email']),
         mysqli_real_escape_string($db,sha1($_POST['password']))
         );


### PR DESCRIPTION
login：delete_flag=0のみログインできるようにする
admin：shoppingスタイルをチェックできなくする
admin：admin_checkから戻った時に、すでに選んだ国をチェック済みにする